### PR TITLE
tests: adding tests for MessageProxy

### DIFF
--- a/packages/backend/src/studio.spec.ts
+++ b/packages/backend/src/studio.spec.ts
@@ -22,7 +22,11 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { Studio } from './studio';
 import type { ExtensionContext } from '@podman-desktop/api';
 
-const mockedExtensionContext = {} as unknown as ExtensionContext;
+const mockedExtensionContext = {
+  subscriptions: {
+    push: vi.fn()
+  }
+} as unknown as ExtensionContext;
 
 const studio = new Studio(mockedExtensionContext);
 

--- a/packages/backend/vitest.config.js
+++ b/packages/backend/vitest.config.js
@@ -17,13 +17,20 @@
  ***********************************************************************/
 
 import path from 'node:path';
+import { join } from 'path';
+
+const PACKAGE_ROOT = __dirname;
 
 const config = {
   test: {
+    include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)', '../shared/**/*.{test,spec}.?(c|m)[jt]s?(x)']
   },
   resolve: {
     alias: {
       '@podman-desktop/api': path.resolve(__dirname, '__mocks__/@podman-desktop/api.js'),
+      '/@/': join(PACKAGE_ROOT, 'src') + '/',
+      '/@gen/': join(PACKAGE_ROOT, 'src-generated') + '/',
+      '@shared/': join(PACKAGE_ROOT, '../shared') + '/',
     },
   },
 };

--- a/packages/shared/MessageProxy.spec.ts
+++ b/packages/shared/MessageProxy.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect, beforeAll } from 'vitest';
+import { RpcBrowser, RpcExtension } from './MessageProxy';
+import { PodmanDesktopApi } from '../../types/podman-desktop-api';
+import type { Webview } from '@podman-desktop/api';
+
+let webview: Webview;
+let window: Window;
+let api: PodmanDesktopApi;
+
+beforeAll(() => {
+
+  let windowListener: (message: any) => void;
+  let webviewListener: (message: any) => void;
+
+  webview = {
+    onDidReceiveMessage: (listener: (message: any) => void) => {
+      webviewListener = listener;
+    },
+    postMessage: async (message: any): Promise<void> => {
+      windowListener({data: message} as MessageEvent);
+    }
+  } as unknown as Webview;
+
+  window = {
+    addEventListener: (channel: string, listener: (message: any) => void) => {
+      expect(channel).toBe('message');
+      windowListener = listener;
+    },
+  } as unknown as Window;
+
+  api = {
+    postMessage: (message: any) => {
+      webviewListener(message);
+    },
+  } as unknown as PodmanDesktopApi;
+})
+
+test('Test register channel no argument', async () => {
+  const rpcExtension = new RpcExtension(webview);
+  const rpcBrowser = new RpcBrowser(window, api);
+
+  rpcExtension.register('ping', () => {
+    return 'pong';
+  });
+
+  expect(await rpcBrowser.invoke('ping')).toBe('pong');
+});
+
+test('Test register channel one argument', async () => {
+  const rpcExtension = new RpcExtension(webview);
+  const rpcBrowser = new RpcBrowser(window, api);
+
+  rpcExtension.register('double', (value: number) => {
+    return value*2;
+  });
+
+  expect(await rpcBrowser.invoke('double', 4)).toBe(8);
+});
+
+test('Test register channel multiple arguments', async () => {
+  const rpcExtension = new RpcExtension(webview);
+  const rpcBrowser = new RpcBrowser(window, api);
+
+  rpcExtension.register('sum', (...args: number[]) => {
+    return args.reduce((prev, current) => prev+current, 0)
+  });
+
+  expect(await rpcBrowser.invoke('sum', 1, 2, 3, 4, 5)).toBe(15);
+});
+
+test('Test register instance with async', async () => {
+  class Dummy {
+    async ping(): Promise<string> {
+      return 'pong';
+    }
+  }
+
+  const rpcExtension = new RpcExtension(webview);
+  const rpcBrowser = new RpcBrowser(window, api);
+
+  rpcExtension.registerInstance(Dummy, new Dummy());
+
+  const proxy = rpcBrowser.getProxy<Dummy>();
+  expect(await proxy.ping()).toBe('pong');
+});

--- a/packages/shared/MessageProxy.ts
+++ b/packages/shared/MessageProxy.ts
@@ -41,7 +41,7 @@ export class RpcExtension {
 
       if(!this.methods.has(message.channel)) {
         console.error(`Trying to call on an unknown channel ${message.channel}. Available: ${Array.from(this.methods.keys())}`);
-        return;
+        throw new Error('channel does not exist.');
       }
 
       try {
@@ -149,7 +149,7 @@ export class RpcBrowser {
         return;
       reject(new Error('Timeout'));
       this.promises.delete(requestId);
-    }, 10000000);
+    }, 5000);
 
     // Create a Promise
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
This PR is adding some basic tests for the MessageProxy 


> Currently the tests in `src/studio.spec.ts` are failing