### PR TITLE
fix: markdown broken links

### DIFF
--- a/packages/frontend/src/lib/MarkdownRenderer.svelte
+++ b/packages/frontend/src/lib/MarkdownRenderer.svelte
@@ -1,9 +1,0 @@
-<script lang="ts">
-  import SvelteMarkdown from 'svelte-markdown'
-  export let source: string | undefined;
-</script>
-
-<article class="prose min-w-full">
-  <SvelteMarkdown {source} />
-</article>
-

--- a/packages/frontend/src/lib/markdown/LinkComponent.svelte
+++ b/packages/frontend/src/lib/markdown/LinkComponent.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+import { studioClient } from '/@/utils/client.js';
+
+export let href: string = "";
+export let title: string | undefined = undefined;
+export let text: string = "";
+
+const onClick = () => {
+  studioClient.openURL(href);
+}
+</script>
+<!-- href set to void operator to avoid any redirect -->
+<a href="{'javascript:void(0);'}" role="button" title="{title}" on:click={onClick}>{text}</a>

--- a/packages/frontend/src/lib/markdown/MarkdownRenderer.svelte
+++ b/packages/frontend/src/lib/markdown/MarkdownRenderer.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+import SvelteMarkdown from 'svelte-markdown'
+import LinkComponent from '/@/lib/markdown/LinkComponent.svelte';
+export let source: string | undefined;
+</script>
+
+<article class="prose min-w-full">
+  <SvelteMarkdown {source} renderers="{{link: LinkComponent}}" />
+</article>
+

--- a/packages/frontend/src/pages/Model.svelte
+++ b/packages/frontend/src/pages/Model.svelte
@@ -2,7 +2,7 @@
 import NavPage from '/@/lib/NavPage.svelte';
 import Tab from '/@/lib/Tab.svelte';
 import Route from '/@/Route.svelte';
-import MarkdownRenderer from '/@/lib/MarkdownRenderer.svelte';
+import MarkdownRenderer from '/@/lib/markdown/MarkdownRenderer.svelte';
 import type { ModelInfo } from '@shared/models/IModelInfo';
 import { studioClient } from '../utils/client';
 import { onMount } from 'svelte';

--- a/packages/frontend/src/pages/Recipe.svelte
+++ b/packages/frontend/src/pages/Recipe.svelte
@@ -7,7 +7,7 @@ import Tab from '/@/lib/Tab.svelte';
 import Route from '/@/Route.svelte';
 import type { Category } from '@shared/models/ICategory';
 import Card from '/@/lib/Card.svelte';
-import MarkdownRenderer from '/@/lib/MarkdownRenderer.svelte';
+import MarkdownRenderer from '/@/lib/markdown/MarkdownRenderer.svelte';
 import Fa from 'svelte-fa';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
 import { faDownload, faRefresh } from '@fortawesome/free-solid-svg-icons';


### PR DESCRIPTION
Related to #36 

Depends on https://github.com/projectatomic/studio-extension/pull/63

The markdown displayed has links, that messes with the webview routing system. Creating custom renderer for Link objects and opening externally the links when clicked.