### PR TITLE
chore: some workaround for podman-desktop/api

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,13 @@
     "test:backend": "vitest run -r packages/backend --passWithNoTests --coverage",
     "test:shared": "vitest run -r packages/shared --passWithNoTests --coverage",
     "test:unit": "npm run test:backend && npm run test:shared",
-    "typecheck:shared": "tsc --noEmit -p packages/shared/tsconfig.json",
-    "typecheck:frontend": "tsc --noEmit -p packages/frontend/tsconfig.json",
-    "typecheck:backend": "tsc --noEmit -p packages/backend/tsconfig.json",
+    "typecheck:shared": "tsc --noEmit --project packages/shared",
+    "typecheck:frontend": "tsc --noEmit --project packages/frontend",
+    "typecheck:backend": "tsc --noEmit --project packages/backend",
     "typecheck": "npm run typecheck:shared && npm run typecheck:frontend && npm run typecheck:backend"
   },
   "devDependencies": {
+    "@podman-desktop/api": "1.6.0",
     "@typescript-eslint/eslint-plugin": "^6.16.0",
     "@typescript-eslint/parser": "^6.16.0",
     "@vitest/coverage-v8": "^1.1.0",

--- a/packages/backend/src/studio.spec.ts
+++ b/packages/backend/src/studio.spec.ts
@@ -61,7 +61,7 @@ afterEach(() => {
 
 test('check activate ', async () => {
   vi.spyOn(fs.promises, 'readFile').mockImplementation(() => {
-    return '<html></html>';
+    return Promise.resolve('<html></html>');
   });
   await studio.activate();
 

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -6,7 +6,8 @@
     "resolveJsonModule": true,
     "lib": [
       "ES2017",
-      "webworker"
+      "webworker",
+      "dom",
     ],
     "sourceMap": true,
     "outDir": "dist",

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -14,7 +14,7 @@
      * of JS in `.svelte` files.
      */
     "allowJs": true,
-    "checkJs": true
+    "checkJs": true,
   },
   "include": [
     "src/**/*.d.ts",

--- a/types/podman-desktop-api.d.ts
+++ b/types/podman-desktop-api.d.ts
@@ -13,3 +13,132 @@ declare global {
 }
 
 export { PodmanDesktopApi };
+
+
+// TODO: remove when podman desktop API exposes this interface
+declare module '@podman-desktop/api' {
+
+  export namespace window {
+
+    export function createWebviewPanel(viewType: string, title: string, options?: WebviewOptions): WebviewPanel;
+  }
+    export interface Webview {
+      /**
+       * Content settings for the webview.
+       */
+      options: WebviewOptions;
+
+      /**
+       * HTML contents of the webview.
+       *
+       * This should be a complete, valid html document. Changing this property causes the webview to be reloaded.
+       *
+       */
+      html: string;
+
+      /**
+       * Fired when the webview content posts a message.
+       *
+       * Webview content can post strings or json serializable objects back to an extension.
+       */
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      readonly onDidReceiveMessage: Event<any>;
+
+      /**
+       * Post a message to the webview content.
+       */
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      postMessage(message: any): Promise<boolean>;
+
+      /**
+       * Convert a uri for the local file system to one that can be used inside webviews.
+       */
+      asWebviewUri(localResource: Uri): Uri;
+
+      /**
+       * Content security policy source for webview resources.
+       *
+       */
+      readonly cspSource: string;
+    }
+
+    export interface WebviewOptions {
+      readonly localResourceRoots?: readonly Uri[];
+    }
+
+
+    interface WebviewPanel {
+      /**
+       * Identifies the type of the webview panel.
+       */
+      readonly viewType: string;
+
+      /**
+       * Title of the panel shown in UI.
+       */
+      title: string;
+
+      /**
+       * Icon for the panel shown in UI.
+       */
+      iconPath?:
+        | Uri
+        | {
+            /**
+             * The icon path for the light theme.
+             */
+            readonly light: Uri;
+            /**
+             * The icon path for the dark theme.
+             */
+            readonly dark: Uri;
+          };
+
+      /**
+       * {@linkcode Webview} belonging to the panel.
+       */
+      readonly webview: Webview;
+
+      /**
+       * Whether the panel is active (focused by the user).
+       */
+      readonly active: boolean;
+
+      /**
+       * Whether the panel is visible.
+       */
+      readonly visible: boolean;
+
+      /**
+       * Fired when the panel's view state changes.
+       */
+      readonly onDidChangeViewState: Event<WebviewPanelOnDidChangeViewStateEvent>;
+
+      /**
+       * Fired when the panel is disposed.
+       *
+       * This may be because the user closed the panel or because `.dispose()` was
+       * called on it.
+       *
+       * Trying to use the panel after it has been disposed throws an exception.
+       */
+      readonly onDidDispose: Event<void>;
+
+      /**
+       * Show the webview panel.
+       * @param preserveFocus When `true`, the webview will not take focus.
+       */
+      reveal(preserveFocus?: boolean): void;
+
+      /**
+       * Dispose of the webview panel.
+       *
+       * This closes the panel if it showing and disposes of the resources owned by the webview.
+       * Webview panels are also disposed when the user closes the webview panel. Both cases
+       * fire the `onDispose` event.
+       */
+      dispose(): void;
+    }
+
+  }
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -401,6 +401,11 @@
   resolved "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
+"@podman-desktop/api@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@podman-desktop/api/-/api-1.6.0.tgz#4c41957c488b830b7525f6de0aed739bcea1c366"
+  integrity sha512-UNZ61fjmJ+vRjxQhcKqr7ifr+ZDKO9DREHrW0jHqdaVTXS8llw0b9w8DOEOjzB76IY+MgEIrXNW8L5t5S7bCuQ==
+
 "@rollup/rollup-android-arm-eabi@4.9.1":
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.1.tgz#beaf518ee45a196448e294ad3f823d2d4576cf35"


### PR DESCRIPTION
shared package has an issue.
shared module should not depends on 'web' library
because backend importing these classes is a pure Node.JS module

so some classes of shared should be only on frontend

fix a test returning a string and not a promise