### PR TITLE
fix: getLocalModels returns an empty array if the models folder does not exist

### DIFF
--- a/packages/backend/src/managers/modelsManager.spec.ts
+++ b/packages/backend/src/managers/modelsManager.spec.ts
@@ -60,10 +60,7 @@ test('getLocalModels should return models in local directory', () => {
 test('getLocalModels should return an empty array if the models folder does not exist', () => {
   vi.spyOn(os, 'homedir').mockReturnValue('/home/user');
   const existsSyncSpy = vi.spyOn(fs, 'existsSync');
-  existsSyncSpy.mockImplementation((path: string) => {
-    expect(path).toBe('/home/user/aistudio/models');
-    return false;
-  });
+  existsSyncSpy.mockReturnValue(false);
   const manager = new ModelsManager('/home/user/aistudio');
   const models = manager.getLocalModels();
   expect(models).toEqual([]);

--- a/packages/backend/src/managers/modelsManager.spec.ts
+++ b/packages/backend/src/managers/modelsManager.spec.ts
@@ -12,7 +12,11 @@ test('getLocalModels should return models in local directory', () => {
   vi.spyOn(os, 'homedir').mockReturnValue('/home/user');
   const existsSyncSpy = vi.spyOn(fs, 'existsSync');
   existsSyncSpy.mockImplementation((path: string) => {
-    expect(path).toBe('/home/user/aistudio/models');
+    if (process.platform === 'win32') {
+      expect(path).toBe('\\home\\user\\aistudio\\models');
+    } else {
+      expect(path).toBe('/home/user/aistudio/models');
+    }
     return true;
   });
   const readdirSyncMock = vi.spyOn(fs, 'readdirSync') as unknown as MockInstance<
@@ -64,5 +68,9 @@ test('getLocalModels should return an empty array if the models folder does not 
   const manager = new ModelsManager('/home/user/aistudio');
   const models = manager.getLocalModels();
   expect(models).toEqual([]);
-  expect(existsSyncSpy).toHaveBeenCalledWith('/home/user/aistudio/models');
+  if (process.platform === 'win32') {
+    expect(existsSyncSpy).toHaveBeenCalledWith('\\home\\user\\aistudio\\models');
+  } else {
+    expect(existsSyncSpy).toHaveBeenCalledWith('/home/user/aistudio/models');
+  }
 });

--- a/packages/backend/src/managers/modelsManager.spec.ts
+++ b/packages/backend/src/managers/modelsManager.spec.ts
@@ -10,6 +10,11 @@ beforeEach(() => {
 
 test('getLocalModels should return models in local directory', () => {
   vi.spyOn(os, 'homedir').mockReturnValue('/home/user');
+  const existsSyncSpy = vi.spyOn(fs, 'existsSync');
+  existsSyncSpy.mockImplementation((path: string) => {
+    expect(path).toBe('/home/user/aistudio/models');
+    return true;
+  });
   const readdirSyncMock = vi.spyOn(fs, 'readdirSync') as unknown as MockInstance<
     [path: string],
     string[] | fs.Dirent[]
@@ -50,4 +55,17 @@ test('getLocalModels should return models in local directory', () => {
       file: 'model-id-2-model',
     },
   ]);
+});
+
+test('getLocalModels should return an empty array if the models folder does not exist', () => {
+  vi.spyOn(os, 'homedir').mockReturnValue('/home/user');
+  const existsSyncSpy = vi.spyOn(fs, 'existsSync');
+  existsSyncSpy.mockImplementation((path: string) => {
+    expect(path).toBe('/home/user/aistudio/models');
+    return false;
+  });
+  const manager = new ModelsManager('/home/user/aistudio');
+  const models = manager.getLocalModels();
+  expect(models).toEqual([]);
+  expect(existsSyncSpy).toHaveBeenCalledWith('/home/user/aistudio/models');
 });

--- a/packages/backend/src/managers/modelsManager.ts
+++ b/packages/backend/src/managers/modelsManager.ts
@@ -8,6 +8,9 @@ export class ModelsManager {
   getLocalModels(): LocalModelInfo[] {
     const result: LocalModelInfo[] = [];
     const modelsDir = path.join(this.appUserDirectory, 'models');
+    if (!fs.existsSync(modelsDir)) {
+      return [];
+    }
     const entries = fs.readdirSync(modelsDir, { withFileTypes: true });
     const dirs = entries.filter(dir => dir.isDirectory());
     for (const d of dirs) {


### PR DESCRIPTION
Fixes #113 